### PR TITLE
Import unicodecsv

### DIFF
--- a/marckbart.py
+++ b/marckbart.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import csv
+import unicodecsv as csv
 from pymarc import MARCReader
 import os
 import shutil


### PR DESCRIPTION
Unicode support in the default python csv writer is hit and miss. Importing the *unicodecsv* module is one strategy for alleviating the problem and reducing the errors.

Also, this is my first pull request... so please forgive any breach of etiquette.